### PR TITLE
Correct `when` conditions with `php_version`

### DIFF
--- a/roles/php/tasks/main.yml
+++ b/roles/php/tasks/main.yml
@@ -13,19 +13,19 @@
 
 - name: install php5 extensions
   yum: name={{item}}
-  when: php_version < 7
+  when: php_version < 'php70'
   with_items:
     - "{{php_version}}-php-memcached"
     - "{{php_version}}-php-ioncube-loader"
 
 - name: install php7 extensions
   yum: name={{item}}
-  when: php_version >= 7
+  when: php_version >= 'php70'
   with_items:
     - "{{php_version}}-php-memcache"
 
 - name: link some php files (php5)
-  when: php_version < 7
+  when: php_version < 'php70'
   file:
     src: "{{item.from}}"
     dest: "{{item.to}}"
@@ -37,7 +37,7 @@
     - {from: "/opt/remi/{{php_version}}/root/var/log/php-fpm/", to: '/var/log/php-fpm'}
 
 - name: link some php files (php7)
-  when: php_version >= 7
+  when: php_version >= 'php70'
   file:
     src: "{{item.from}}"
     dest: "{{item.to}}"


### PR DESCRIPTION
условия сравнения отрабатывали неверно - всегда отрабатывало `php_version >= 7`